### PR TITLE
patch-1

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -10,25 +10,27 @@ jobs:
   lint:
     name: Linting Python Files
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.12"]  # Change or add versions if needed
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.12
         uses: actions/setup-python@v3
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.12"
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
 
       - name: Upgrade pip and install dependencies.
         run: |
           python -m pip install --upgrade pip
-          # Install your project dependencies. If you have a requirements.txt file, use:
           pip install -r requirements.txt
 
       - name: Lint Python files with pylint
         run: |
-          # If you have a custom configuration file (e.g., .pylintrc), pylint will pick it up automatically.
-          # This command lints all tracked Python files in your repository.
           pylint $(git ls-files '*.py')


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/pylint.yml` file to streamline the linting process for Python files. The most important changes involve simplifying the setup for Python versioning and adding caching for pip dependencies.

Improvements to workflow configuration:

* Removed the matrix strategy for Python versioning and set up Python 3.12 directly. (`.github/workflows/pylint.yml`)
* Added caching for pip dependencies to improve workflow efficiency. (`.github/workflows/pylint.yml`)