### PR TITLE
Ignoring more pylint errors for convenience

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -14,10 +14,12 @@ ignore=.venv,build,dist
 disable=
     trailing-newlines,
     trailing-whitespace,
+    missing-final-newline,
     missing-module-docstring,
     missing-class-docstring,
     missing-function-docstring,
-    invalid-name
+    invalid-name,
+    redefined-outer-name
 
 [REPORTS]
 # Disable the full report; only errors and warnings are shown.


### PR DESCRIPTION
This pull request includes updates to the `.pylintrc` configuration file to enhance code linting rules. The most important changes involve adding new rules to the `disable` section.

Enhancements to linting rules:

* [`.pylintrc`](diffhunk://#diff-ba293004ae8f18975051e825bd8d5c70137a8b5d42d16e0f7c9354aa634c446cR17-R22): Added `missing-final-newline` to the list of disabled checks.
* [`.pylintrc`](diffhunk://#diff-ba293004ae8f18975051e825bd8d5c70137a8b5d42d16e0f7c9354aa634c446cR17-R22): Added `redefined-outer-name` to the list of disabled checks.