### PR TITLE
Update pylint workflow: add permissions, cache pip dependencies, and …

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -6,29 +6,34 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Linting Python Files
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.12"]  # Change or add versions if needed
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.12
         uses: actions/setup-python@v3
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.12"
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
 
       - name: Upgrade pip and install dependencies.
         run: |
           python -m pip install --upgrade pip
-          # Install your project dependencies. If you have a requirements.txt file, use:
           pip install -r requirements.txt
 
       - name: Lint Python files with pylint
         run: |
-          # If you have a custom configuration file (e.g., .pylintrc), pylint will pick it up automatically.
-          # This command lints all tracked Python files in your repository.
           pylint $(git ls-files '*.py')


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow for linting Python files. The most important changes include adding permissions, simplifying the Python setup, and improving the caching of pip dependencies.

Workflow improvements:

* [`.github/workflows/pylint.yml`](diffhunk://#diff-3fb2867e4a7c0ecbfdf0f36a3078f1689dca17453c5e0ebdd0671bb94733b5a3R9-L33): Added read permissions for contents.
* [`.github/workflows/pylint.yml`](diffhunk://#diff-3fb2867e4a7c0ecbfdf0f36a3078f1689dca17453c5e0ebdd0671bb94733b5a3R9-L33): Simplified the Python setup by removing the matrix strategy and explicitly setting the Python version to 3.12.
* [`.github/workflows/pylint.yml`](diffhunk://#diff-3fb2867e4a7c0ecbfdf0f36a3078f1689dca17453c5e0ebdd0671bb94733b5a3R9-L33): Added a step to cache pip dependencies to speed up subsequent runs.